### PR TITLE
Added xargs option --no-run-if-empty

### DIFF
--- a/fan_speed.sh
+++ b/fan_speed.sh
@@ -2,10 +2,10 @@
 
 startpath="/sys/devices/virtual/thermal/"
 path1=$(grep -r '^Fan$' ${startpath}cooling_device*/type 2> /dev/null | \
-	cut -d ":" -f 1 | xargs dirname)
+	cut -d ":" -f 1 | xargs --no-run-if-empty dirname)
 
 path2=$(grep -r '^GFX Fan$' ${startpath}cooling_device*/type 2> /dev/null | \
-	cut -d ":" -f 1 | xargs dirname)
+	cut -d ":" -f 1 | xargs --no-run-if-empty dirname)
 
 function usage() {
   echo "Usage: `basename $0` [fan index] <action>"


### PR DESCRIPTION
to eliminate 
"dirname: missing operand
Try 'dirname --help' for more information."
errors that occur when the dirname is run with no options supplied.

See http://unix.stackexchange.com/questions/131592/blank-lines-when-executing-grep-xargs-in-a-find-exec for a way to do this with find that they say is safer.
