### PR TITLE
Use a more standard linux module Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,12 @@
-obj-m := asus_fan.o
-KDIR := /lib/modules/$(shell  uname -r)/build
+KDIR ?= /lib/modules/$(shell uname -r)/build
 
-PWD := $(shell pwd)
+obj-m := asus_fan.o
 
 all:
-	$(MAKE) -C $(KDIR) M=$(PWD) modules
+	make -C $(KDIR) M=$$PWD modules
 
 install:
-	# just copy the .ko file anywhere below:
-	# /lib/modules/$(uname -r)/
-	#
-	# finally add it to some on-boot-load-mechanism
-	# the module will _not_ automatically load.
-	cp asus_fan.ko "/lib/modules/$(shell uname -r)/"
-	depmod -a
+	make -C $(KDIR) M=$$PWD modules_install
+
+clean:
+	make -C $(KDIR) M=$$PWD clean


### PR DESCRIPTION
This adds a clean option, uses the install option provided by the kernel
instead of a self-baked one and lets users specify their own KDIR.