### PR TITLE
Fixed systemd unit file to activate after thermald, if it exists.

### DIFF
--- a/misc/systemd/asus-fan.service
+++ b/misc/systemd/asus-fan.service
@@ -1,9 +1,10 @@
-[Unit]                                                                                        
+[Unit]
 Description=Create tmp-files to provide a consistent naming and location
-
-[Service]                                                                                     
-ExecStart=/usr/bin/asus-fan-create-symlinks.sh                      
-
-[Install]                                                                                     
-WantedBy=multi-user.target
+Wants=thermald.service
 Before=thermald.service
+
+[Service]
+ExecStart=/usr/bin/asus-fan-create-symlinks.sh
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The Before= directive can only be specified in the [Unit] section, as documented in the [systemd.unit manpage](https://www.freedesktop.org/software/systemd/man/systemd.unit.html).

The Before= (and After=) directive(s) only define the ordering of activated units, which is orthogonal to the dependency of units; that's defined through the Wants= and Requires= directives, so I've added the Wants=thermald.service directive to activate thermald.service when asus-fan.service is activated. Without this change, thermald.service does not start when asus-fan.service is activated; it's simply ordered to start before asus-fan.service if it is activated through some other mechanism.
