### PR TITLE
issues#66 Allow override of rpm check for some cases

### DIFF
--- a/asus_fan.c
+++ b/asus_fan.c
@@ -936,6 +936,9 @@ static int __init fan_init(void) {
     // USE this for idx in hwmon_attrs size_t idx = 0;
     // try to get RPM for first fan
     rpm = __fan_rpm(0);
+    if (force_rpm_override){
+      info_mesg("init", "overriding rpm check: USE WITH CARE");
+    }
     if (rpm == -1 && !force_rpm_override) {
       asus_data.has_fan = false;
       err_msg("init", "fan-id: 1 | failed to get rpm");

--- a/asus_fan.c
+++ b/asus_fan.c
@@ -446,8 +446,7 @@ static int __fan_rpm(int fan) {
     // acpi call
     ret = acpi_evaluate_integer(NULL, "\\_SB.PCI0.LPCB.EC0.TACH", &params,
                                 &value);
-
-    dbg_msg("|--> acpi request returned: %d", (unsigned int)ret);
+    dbg_msg("|--> acpi request returned: %s", acpi_format_exception(ret));
     if (ret != AE_OK)
       return -1;
   }
@@ -995,22 +994,24 @@ static int __init fan_init(void) {
       return -ENODEV;
     }
 
-    dbg_msg("fan_set_max_speed() call succeeded, ret: %d", (unsigned int)ret);
+    dbg_msg("fan_set_max_speed() call succeeded, ret: %s",
+     acpi_format_exception(ret));
 
     // force sane enviroment / init with automatic fan controlling
     if ((ret = fan_set_auto()) != AE_OK) {
-      err_msg("init", "set auto-mode speed to active, failed! errcode: %d",
-              ret);
+      err_msg("init", "set auto-mode speed to active, failed! errcode: %s",
+              acpi_format_exception(ret));
       return -ENODEV;
     }
 
-    dbg_msg("fan_set_auto() call succeeded, ret: %d", (unsigned int)ret);
+    dbg_msg("fan_set_auto() call succeeded, ret: %s",
+     acpi_format_exception(ret));
   }
 
   ret = asus_fan_register_driver(&asus_fan_driver);
   if (ret != AE_OK) {
-    err_msg("init", "set max speed to: '%d' failed! errcode: %d",
-            asus_data.max_fan_speed_default, ret);
+    err_msg("init", "set max speed to: '%d' failed! errcode: %s",
+            asus_data.max_fan_speed_default, acpi_format_exception(ret));
     return ret;
   }
 

--- a/asus_fan.c
+++ b/asus_fan.c
@@ -616,7 +616,8 @@ static int fan_set_max_speed(unsigned long state, bool reset) {
     ret = acpi_evaluate_integer(NULL, "\\_SB.ATKD.QMOD", &params, &value);
     if (ret != AE_OK) {
       err_msg("set_max_speed",
-              "set max fan speed(s) failed (force reset)! errcode: %d", ret);
+              "set max fan speed(s) failed (force reset)! errcode: %s",
+              acpi_format_exception(ret));
       return ret;
     }
 
@@ -637,7 +638,8 @@ static int fan_set_max_speed(unsigned long state, bool reset) {
                                 &value);
     if (ret != AE_OK) {
       err_msg("set_max_speed",
-              "set max fan speed(s) failed (no reset) errcoded", ret);
+              "set max fan speed(s) failed (no reset) errcode: %s",
+              acpi_format_exception(ret));
 
       return ret;
     }
@@ -680,8 +682,8 @@ static int fan_set_auto() {
   if (ret != AE_OK) {
     err_msg("set_auto",
             "failed reseting fan(s) to auto-mode! "
-            "errcode: %d - DANGER! OVERHEAT? DANGER!",
-            ret);
+            "errcode: %s - DANGER! OVERHEAT? DANGER!",
+            acpi_format_exception(ret));
 
     return ret;
   }
@@ -737,7 +739,8 @@ static ssize_t temp1_input(struct device *dev, struct device_attribute *attr,
   // acpi call
   ret = acpi_evaluate_integer(NULL, "\\_SB.PCI0.LPCB.EC0.TH1R", NULL, &value);
   if (ret != AE_OK) {
-    err_msg("read_temp", "failed reading temperature, errcode: %d", ret);
+    err_msg("read_temp", "failed reading temperature, errcode: %s",
+     acpi_format_exception(ret));
     return ret;
   }
   size = sprintf((char *)&buf, "%llu\n", value);
@@ -989,8 +992,8 @@ static int __init fan_init(void) {
     // check if reseting fan speeds works
     ret = fan_set_max_speed(asus_data.max_fan_speed_default, false);
     if (ret != AE_OK) {
-      err_msg("init", "set max speed to: '%d' failed! errcode: %d",
-              asus_data.max_fan_speed_default, ret);
+      err_msg("init", "set max speed to: '%d' failed! errcode: %s",
+              asus_data.max_fan_speed_default, acpi_format_exception(ret));
       return -ENODEV;
     }
 

--- a/asus_fan.c
+++ b/asus_fan.c
@@ -937,7 +937,7 @@ static int __init fan_init(void) {
     // try to get RPM for first fan
     rpm = __fan_rpm(0);
     if (force_rpm_override){
-      info_mesg("init", "overriding rpm check: USE WITH CARE");
+      info_msg("init", "overriding rpm check: USE WITH CARE");
     }
     if (rpm == -1 && !force_rpm_override) {
       asus_data.has_fan = false;


### PR DESCRIPTION
Attempt to resolve issue reported in: https://github.com/daringer/asus-fan/issues/66
Seems that the module loads/checks too quickly. The ACPI chip on the G752 series seems to no always respond in time/at all to all requests. Some come through some fail...

Adds a module parameter to ignore rpm check on init. As you can send instructions to fan regardless.